### PR TITLE
Pipe stdout directly to the terminal when building

### DIFF
--- a/app.go
+++ b/app.go
@@ -68,13 +68,17 @@ func main() {
 		fmt.Println(strings.Join(builder, " "))
 		targetCmd := exec.Command(builder[0], builder[1:]...)
 		targetCmd.Dir = tempPath
-		cmdOutput, cmdErr := targetCmd.CombinedOutput()
+		targetCmd.Stdout = os.Stdout
+
+		var stderr bytes.Buffer
+		targetCmd.Stderr = &stderr
+		targetCmd.Start()
+		cmdErr := targetCmd.Wait()
 
 		if cmdErr != nil {
-			fmt.Printf("Error: %s\n" + cmdErr.Error())
+			fmt.Printf("Error: %s\n", cmdErr)
+			fmt.Printf(stderr.String())
 		}
-
-		fmt.Println(string(cmdOutput))
 
 		fmt.Printf("Image: %s built.\n", image)
 	} else if action == "deploy" {

--- a/app.go
+++ b/app.go
@@ -69,15 +69,13 @@ func main() {
 		targetCmd := exec.Command(builder[0], builder[1:]...)
 		targetCmd.Dir = tempPath
 		targetCmd.Stdout = os.Stdout
-
-		var stderr bytes.Buffer
-		targetCmd.Stderr = &stderr
+		targetCmd.Stderr = os.Stderr
 		targetCmd.Start()
+
 		cmdErr := targetCmd.Wait()
 
 		if cmdErr != nil {
 			fmt.Printf("Error: %s\n", cmdErr)
-			fmt.Printf(stderr.String())
 		}
 
 		fmt.Printf("Image: %s built.\n", image)


### PR DESCRIPTION
What it says on the tin but it essentially attaches the command's `stdout` to the terminal and does some funky referencing in case we get errors. This means you can see the command's output as it comes in, instead of waiting for it all in one go. Much nicer for slower `docker build`'s etc.

Tested with both failing and passing commands, all works as expected.

Thoughts? 💡🔎