### PR TITLE
Add -skipBuild flag for non-built images

### DIFF
--- a/app.go
+++ b/app.go
@@ -80,10 +80,14 @@ func main() {
 	case "build":
 		if len(services.Functions) > 0 {
 			for k, function := range services.Functions {
-				function.Name = k
-				// fmt.Println(k, function)
-				fmt.Printf("Building: %s.\n", function.Name)
-				buildImage(function.Image, function.Handler, function.Name, function.Language, nocache)
+				if function.SkipBuild {
+					fmt.Printf("Skipping build of: %s.\n", function.Name)
+				} else {
+					function.Name = k
+					// fmt.Println(k, function)
+					fmt.Printf("Building: %s.\n", function.Name)
+					buildImage(function.Image, function.Handler, function.Name, function.Language, nocache)
+				}
 			}
 		} else {
 			if len(image) == 0 {

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker build -t faas-cli . && \
+docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t faas-cli . && \
  docker create --name faas-cli faas-cli && \
  docker cp faas-cli:/root/faas-cli . && \
  docker rm -f faas-cli

--- a/schema.go
+++ b/schema.go
@@ -21,6 +21,8 @@ type Function struct {
 	FProcess string `yaml:"fprocess"`
 
 	Environment map[string]string `yaml:"environment"`
+
+	SkipBuild bool `yaml:"skipBuild"`
 }
 
 // Services root level YAML file to define FaaS function-set


### PR DESCRIPTION
This helps with images which are part of the stack but are not built or do not need to be rebuilt by the faas-cli at this time. 