### PR TITLE
Use '-S' instead of '-s' when signing Git commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,6 @@ Here are a few guidelines for contributing:
 
 **Practical stuff**
 
-* Please sign your commits with `git commit -s` so that commits are traceable.
+* Please sign your commits with `git commit -S` so that commits are traceable.
 * Please always provide a summary of what you changed, how you did it and how it can be tested
 


### PR DESCRIPTION
Update the `CONTRIBUTING.md` doc to use the correct cli flag for signing Git commits.

## Description
As per https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work the correct flag for signing commits is `-S`. 

## Motivation and Context
Avoid confusion when submitting pull requests.

- [ ] I have raised an issue to propose this change

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
