### PR TITLE
Add bump-formula-pr to Brew update steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,23 @@ $ uname -a | curl http://localhost:8080/function/nodejs-echo--data-binary @-
 
 ## FaaS-CLI Developers / Contributors
 
-**Updating the brew formula**
+### Updating the brew formula
 
 The `brew` formula for the faas-cli is part of the official [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/faas-cli.rb) repo on Github. It needs to be updated for each subsequent release.
 
-These are the guidelines for updating brew:
+#### Simple version bumps
+
+If the only change required is a version bump, ie no new tests, or changes to existing tested functionality or build steps, the `brew bump-formula-pr` command can be used to do everything (i.e. forking, committing, pushing) required to bump the version.
+
+For example (supplying both the new version tag and its associated Git sha-256).
+
+```
+brew bump-formula-pr --strict faas-cli --tag=<version> --revision=<sha-256>
+```
+
+#### Changes requiring new/update tests/build steps
+
+If a new release alters behaviour tested in the Brew Formula, adds new testable behaviors or alters the build steps then you will need to manually raise a PR with an updated Formula, the guidelines for updating brew describe the process in more detail:
 
 https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md
 
@@ -117,7 +129,7 @@ $ brew uninstall --force faas-cli ; \
   brew audit --strict faas-cli
 ```
 
-**Updating the utility-script**
+### Updating the utility-script
 
 Please raise a PR for the get.sh file held in this repository. It's used when people install via `curl` and `cli.openfaas.com`. The updated file then has to be redeployed to the hosting server.
 


### PR DESCRIPTION
## Description
This PR updates the Brew Formula update steps to include the `bump-formula-pr` command for use with simple version bumps.

## Motivation and Context
Its expected that the bulk of updates should not require manual PRs to be raised against Brew, the `bump-formula-pr` command offers a much simpler process and is usually approved more quickly by the upstream project.

- [ ] I have raised an issue to propose this change

## How Has This Been Tested?
This process was used for the recent `0.4.6` release.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
