### PR TITLE
Update get.sh to determine latest full release from Github

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -1,4 +1,4 @@
-version=0.3
+version=$(curl -s https://api.github.com/repos/alexellis/faas-cli/releases/latest | grep 'tag_name' | cut -d\" -f4)
 
 hasCli() {
     has=$(which faas-cli)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the one-line installer `get.sh` to use the latest full release from Github rather than use a hard-coded version string.

Draft releases and prereleases are not returned by the endpoint used to determine the version.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently `get.sh` uses a hardcoded version, the script hosted on https://cli.openfaas.com pulls in an outdated version 0.4.5b

- [ ] I have raised an issue to propose this change

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Linux (Alpine, Fedora, Ubuntu, CentOS), and OSX.

For example:
```
$ sudo ./get.sh
Password:
Getting package https://github.com/alexellis/faas-cli/releases/download/0.4.7/faas-cli-darwin
Attemping to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
