### PR TITLE
Added recusion to handler copy + debugPrint fn

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -72,7 +72,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 	}
 
 	if pullErr := pullTemplates(); pullErr != nil {
-		log.Fatalln("Could not pull templates for FaaS.", pullErr)
+		log.Fatalln("Could not pull templates for OpenFaaS.", pullErr)
 	}
 
 	if len(services.Functions) > 0 {


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

Addresses issue #59.  

## Description
Changes the recursive arg to true on the handler `copyFiles` call so that sub directories within the handler are also copied into the build directory. 
Extracted a `debugPrint` function to avoid code repetition as The new directory branch in `copyFiles` now messages out only if the system is creating a new directory and `debug` is enabled.
Corrected a typo which meant that `err` was being tested rather than `newDirErr` when a new directory is being created.
Changed FaaS to OpenFaaS where seen.

## Motivation and Context
#59
- [X] There is a raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Created 10 levels of files and folders beneath a handler folder
Ran ./faas-cli -action build -yaml ./samples.yml
Confirmed that the images built successfully.
Confirmed that the expected files and folders were extant in the build folder following completion of build

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
