### PR TITLE
Fix importpath in Go linker -X ldflag - fixes #62

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
   - go get -d -v
-  - go build
+  - ./build.sh
   - ./build_samples.sh
   - ./test/version.sh ./faas-cli
 #  - ./deploy_samples.sh # requires a deployed FaaS

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ script:
   - go get -d -v
   - go build
   - ./build_samples.sh
+  - ./test/version.sh ./faas-cli
 #  - ./deploy_samples.sh # requires a deployed FaaS

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /go/src/github.com/alexellis/faas-cli
 COPY . .
 RUN go get -d -v
 
-RUN CGO_ENABLED=0 GOOS=linux go build --ldflags "-X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli .
+RUN GIT_COMMIT=$(git rev-list -1 HEAD) \
+ && CGO_ENABLED=0 GOOS=linux go build --ldflags "-X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli .
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/alexellis/faas-cli
 COPY . .
 RUN go get -d -v
 
-RUN CGO_ENABLED=0 GOOS=linux go build --ldflags "-X commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli .
+RUN CGO_ENABLED=0 GOOS=linux go build --ldflags "-X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli .
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -5,10 +5,10 @@ COPY . .
 RUN go get -d -v
 
 RUN GIT_COMMIT=$(git rev-list -1 HEAD) \
- && GOARCH=arm GOARM=6 CGO_ENABLED=0 GOOS=linux go build --ldflags "-X commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli-armhf \
- && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-X commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli-darwin \
- && CGO_ENABLED=0 GOOS=linux go build --ldflags "-X commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli \
- && CGO_ENABLED=0 GOOS=windows go build --ldflags "-X commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli.exe
+ && GOARCH=arm GOARM=6 CGO_ENABLED=0 GOOS=linux go build --ldflags "-X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli-armhf \
+ && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli-darwin \
+ && CGO_ENABLED=0 GOOS=linux go build --ldflags "-X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli \
+ && CGO_ENABLED=0 GOOS=windows go build --ldflags "-X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT}" -a -installsuffix cgo -o faas-cli.exe
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates

--- a/test/version.sh
+++ b/test/version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -x
+
+FAAS_BINARY=$1
+GIT_COMMIT=$(git rev-list -1 HEAD)
+
+echo "TEST: Version command prints GitCommit"
+${FAAS_BINARY} version | tee /dev/stderr | grep ${GIT_COMMIT}
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+    exit 1
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the importpath to fully identify the `commands` package so that the GitCommit var can be populated at build time. The associated issue was raised in #62 and originally spotted by @ems5311 - thanks!!

This will fix binaries build by the `build_redist.sh` script, with the Brew built release requiring the same update in the homebrew-core formula (ie bumping the version on the command line isn't sufficient this time).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Built manually passing in the version ldflag option and then ran `./faas-cli version`
- Built all the platform variants via `build_redist.sh` and then ran `./faas-cli version` on MacOS and Ubuntu
- In both cases above the GitCommit was populated as expected.
```
root@ff2edcc0885b:/# /faas/faas-cli version
Git Commit: b877c56f07d5b0ab6c417cb9eeeb06126e58031a
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
