### PR TITLE
Remove master.zip file after building function with faas-cli build

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -75,7 +75,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if pullErr := PullTemplates(); pullErr != nil {
+	if pullErr := PullTemplates(""); pullErr != nil {
 		log.Fatalln("Could not pull templates for OpenFaaS.", pullErr)
 	}
 
@@ -114,13 +114,13 @@ func runBuild(cmd *cobra.Command, args []string) {
 }
 
 // PullTemplates pulls templates from Github from the master zip download file.
-func PullTemplates() error {
+func PullTemplates(templateUrl string) error {
 	var err error
 	exists, err := os.Stat("./template")
 	if err != nil || exists == nil {
 		log.Println("No templates found in current directory.")
 
-		err = fetchTemplates()
+		err = fetchTemplates(templateUrl)
 		if err != nil {
 			log.Println("Unable to download templates from Github.")
 			return err

--- a/commands/fetch_templates_test.go
+++ b/commands/fetch_templates_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Alex Ellis, Eric Stoekl 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+package commands
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+var SmallestZipFile = []byte{80, 75, 05, 06, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00}
+
+func Test_PullTemplates(t *testing.T) {
+	// Remove existing master.zip file if it exists
+	if _, err := os.Stat("master.zip"); err == nil {
+		t.Log("Found a master.zip file, removing it...")
+
+		err := os.Remove("master.zip")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Remove existing templates folder, if it exist
+	if _, err := os.Stat("template/"); err == nil {
+		t.Log("Found a template/ directory, removing it...")
+
+		err := os.RemoveAll("template/")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create fake server for testing.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Write out the minimum number of bytes to make the response a valid .zip file
+		w.Write(SmallestZipFile)
+
+	}))
+	defer ts.Close()
+
+	err := PullTemplates(ts.URL)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -63,7 +63,7 @@ the "Dockerfile" lang type in your YAML file.
 		return
 	}
 
-	PullTemplates()
+	PullTemplates("")
 
 	if _, err := os.Stat(functionName); err == nil {
 		fmt.Printf("Folder: %s already exists\n", functionName)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change will remove the master.zip file after the `fetchTemplates()` function is done creating the templates from the downloaded zip file.

## Description
<!--- Describe your changes in detail -->
Use the `os.Remove()` function to remove the zip file, whose name is now stored in a const variable, after making sure that the zip file is still present with `os.Stat()`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))
Noticed the zip file hanging around, was confused as to its necessity to remain the directory. However, as long as the `templates` directory is present in your YAML build file location, the `master.zip` file will not be used. Therefore, it is not necessary to keep it around.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried building the node, python, csharp, ruby, and Dockerfile templates, and checked that the master.zip file was removed, but the function worked when deployed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.