### PR TITLE
Assorted minor fixes while testing new faas-cli subcommands

### DIFF
--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -71,7 +71,11 @@ func runInvoke(cmd *cobra.Command, args []string) {
 		gatewayAddress = gateway
 	}
 
-	fmt.Fprintf(os.Stderr, "Reading from STDIN - hit (Control + D) to stop.\n")
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		fmt.Fprintf(os.Stderr, "Reading from STDIN - hit (Control + D) to stop.\n")
+	}
+
 	functionInput, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Printf("Unable to read standard input: %s\n", err.Error())

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -47,7 +47,6 @@ var invokeCmd = &cobra.Command{
 
 func runInvoke(cmd *cobra.Command, args []string) {
 	var services stack.Services
-	var gatewayAddress string
 
 	if len(functionName) == 0 {
 		fmt.Println("Give a function to invoke via --name")
@@ -63,12 +62,8 @@ func runInvoke(cmd *cobra.Command, args []string) {
 
 		if parsedServices != nil {
 			services = *parsedServices
-			gatewayAddress = services.Provider.GatewayURL
+			gateway = services.Provider.GatewayURL
 		}
-	}
-
-	if len(gateway) > 0 && gateway != "http://localhost:8080" {
-		gatewayAddress = gateway
 	}
 
 	stat, _ := os.Stdin.Stat()
@@ -82,7 +77,7 @@ func runInvoke(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	response, err := proxy.InvokeFunction(gatewayAddress, functionName, &functionInput, contentType)
+	response, err := proxy.InvokeFunction(gateway, functionName, &functionInput, contentType)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -38,8 +38,8 @@ var invokeCmd = &cobra.Command{
 	Use: `invoke --gateway GATEWAY_URL
   faas-cli invoke [--gateway GATEWAY_URL] [--content-type CONTENT_TYPE] STDIN`,
 
-	Short: "invoke an OpenFaaS function",
-	Long:  `invokes an OpenFaaS function and reads from STDIN for the body of the request`,
+	Short: "Invoke an OpenFaaS function",
+	Long:  `Invokes an OpenFaaS function and reads from STDIN for the body of the request`,
 	Example: `  faas-cli invoke --gateway https://domain:port --name echo
   faas-cli invoke --gateway https://domain:port --name echo --content-type application/json`,
 	Run: runInvoke,

--- a/commands/list.go
+++ b/commands/list.go
@@ -31,12 +31,11 @@ func init() {
 }
 
 var listCmd = &cobra.Command{
-	Use: `list --gateway GATEWAY_URL
-  faas-cli list [--gateway GATEWAY_URL] [--verbose]`,
+	Use: `list [--gateway GATEWAY_URL] [--verbose]`,
 
 	Short: "List OpenFaaS functions",
 	Long:  `Lists OpenFaaS functions either on a local or remote gateway`,
-	Example: `  faas-cli list --gateway https://domain:port
+	Example: `  faas-cli list
   faas-cli list --gateway https://localhost:8080 --verbose`,
 	Run: runList,
 }

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -21,7 +21,7 @@ func init() {
 	newFunctionCmd.Flags().StringVar(&functionName, "name", "", "Name for your function")
 	newFunctionCmd.Flags().StringVar(&lang, "lang", "", "Language or template to use")
 	newFunctionCmd.Flags().StringVar(&gateway, "gateway", "http://localhost:8080",
-		"Gateway URL or http://localhost:8080 to store in YAML stack file")
+		"Gateway URL to store in YAML stack file")
 
 	newFunctionCmd.Flags().BoolVar(&list, "list", false, "List available languages")
 
@@ -30,12 +30,12 @@ func init() {
 
 // newFunctionCmd displays newFunction information
 var newFunctionCmd = &cobra.Command{
-	Use:   "new [--name] [--lang] [--list]",
+	Use:   "new (--name=FUNCTION_NAME --lang=FUNCTION_LANGUAGE [--gateway=http://domain:port] | --list)",
 	Short: "Create a new template in the current folder with the name given as name",
-	Long: fmt.Sprintf(`The new command creates a new function based upon hello-world in the
-given language or type in --list for a list of languages available.`),
-	Example: `  faas-cli new
-  faas-cli new --name chatbot --lang node
+	Long: `The new command creates a new function based upon hello-world in the given
+language or type in --list for a list of languages available.`,
+	Example: `faas-cli new --name chatbot --lang node
+  faas-cli new --name textparser --lang python --gateway http://mydomain:8080
   faas-cli new --list`,
 	Run: runNewFunction,
 }
@@ -54,12 +54,12 @@ the "Dockerfile" lang type in your YAML file.
 		return
 	}
 	if len(functionName) == 0 {
-		fmt.Printf("You must give a --function name\n")
+		fmt.Println("You must supply a function name with the --name flag")
 		return
 	}
 
 	if len(lang) == 0 {
-		fmt.Printf("You must give a --lang parameter\n")
+		fmt.Println("You must supply a function language with the --lang flag")
 		return
 	}
 

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -9,12 +9,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/alexellis/faas/gateway/requests"
 )
 
 // DeleteFunction delete a function from the FaaS server
 func DeleteFunction(gateway string, functionName string) {
+	gateway = strings.TrimRight(gateway, "/")
 	delReq := requests.DeleteFunctionRequest{FunctionName: functionName}
 	reqBytes, _ := json.Marshal(&delReq)
 	reader := bytes.NewReader(reqBytes)

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/alexellis/faas/gateway/requests"
 )
@@ -29,6 +30,8 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	} else if language == "csharp" {
 		fprocessTemplate = "dotnet ./bin/Debug/netcoreapp2.0/root.dll"
 	}
+
+	gateway = strings.TrimRight(gateway, "/")
 
 	if replace {
 		DeleteFunction(gateway, functionName)

--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -8,11 +8,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // InvokeFunction a function
 func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType string) (*[]byte, error) {
 	var resBytes []byte
+
+	gateway = strings.TrimRight(gateway, "/")
 
 	reader := bytes.NewReader(*bytesIn)
 	res, err := http.Post(gateway+"/function/"+name, contentType, reader)

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/alexellis/faas/gateway/requests"
 )
@@ -15,6 +16,8 @@ import (
 // ListFunctions list deployed functions
 func ListFunctions(gateway string) ([]requests.Function, error) {
 	var results []requests.Function
+
+	gateway = strings.TrimRight(gateway, "/")
 
 	res, err := http.Get(gateway + "/system/functions")
 	if err != nil {

--- a/sample/url-ping/handler.py
+++ b/sample/url-ping/handler.py
@@ -8,11 +8,12 @@ def print_url(url):
         print("Timed out trying to reach URL.")
 
 def handle(req):
-    print("Handle this -> " + req)
-    if req.find("http") == -1:
+    url = req.rstrip()
+    print("Handle this -> " + url)
+    if url.find("http") == -1:
         print("Give me a URL and I'll ping it for you.")
         return
     
-    print_url(req)
+    print_url(url)
 
 # handle("http://faaster.io")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR includes a number of minor fixes to issues found when reviewing the new `faas-cli` subcommands - `invoke`, `list`, `new`.

Please see the individual commits (1 per issue) for more details on each issue.

- Fixes capitalisation in `invoke` help
- Fix handling for gateway URLs, removing trailing `\`
- Fix `url-ping` function so that it works when used with `invoke`
- Suppress `Reading from STDIN..` message when STDIN is piped to the `invoke`
- Fix handling of the default Gateway URL in the `invoke` command
- Fix help text in the `new` function command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on a swarm instance, details of the tested commands are given in each commit.jj

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
