### PR TITLE
[WIP] Use multi-stage build for CSharp

### DIFF
--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -28,7 +28,7 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	} else if language == "ruby" {
 		fprocessTemplate = "ruby index.rb"
 	} else if language == "csharp" {
-		fprocessTemplate = "dotnet ./bin/Debug/netcoreapp2.0/root.dll"
+		fprocessTemplate = "dotnet ./root.dll"
 	}
 
 	gateway = strings.TrimRight(gateway, "/")

--- a/template/csharp/Dockerfile
+++ b/template/csharp/Dockerfile
@@ -1,4 +1,14 @@
-FROM microsoft/dotnet:2.0-sdk
+FROM microsoft/dotnet:2.0-sdk as builder
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
+
+WORKDIR /root/
+WORKDIR /root/src
+COPY .  .
+RUN dotnet restore ./root.csproj
+RUN dotnet publish -c release -o published
+
+FROM microsoft/dotnet:2.0-runtime
 
 #ADD https://github.com/alexellis/faas/releases/download/0.6.1/fwatchdog /usr/bin
 RUN apt-get update -qy \
@@ -10,14 +20,10 @@ RUN apt-get update -qy \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
-
 WORKDIR /root/
-WORKDIR /root/src
-COPY .  .
-RUN dotnet restore ./root.csproj
-RUN dotnet build
+COPY --from=builder /root/src/published .
 
-ENV fprocess="dotnet ./bin/Debug/netcoreapp2.0/root.dll"
+ENV fprocess="dotnet ./root.dll"
 EXPOSE 8080
 CMD ["fwatchdog"]
+


### PR DESCRIPTION
Signed-off-by: Robbie Page <rob@rorpage.com>

## Description
I have updated the csharp template to use multi-stage. The first stage is using the dotnet SDK, and the second uses the runtime.

## Motivation and Context
The dotnet images are rather large so by implementing a multi-stage build, we decrease the end function image.
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))
[#53](https://github.com/alexellis/faas-cli/issues/53)

## How Has This Been Tested?
I updated my template locally, created a new csharp function, built, deployed, and invoked the function and saw that everything ran as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
