### PR TITLE
Allow to override the network name from CLI

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -30,6 +30,7 @@ func init() {
 	deployCmd.Flags().StringVar(&image, "image", "", "Docker image name to build")
 	deployCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
 	deployCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
+	deployCmd.Flags().StringVar(&network, "network", defaultNetwork, "Name of the network")
 
 	// Setup flags that are used only by this command (variables defined above)
 	deployCmd.Flags().StringArrayVarP(&envvarOpts, "env", "e", []string{}, "Set one or more environment variables (ENVVAR=VALUE)")
@@ -50,6 +51,7 @@ var deployCmd = &cobra.Command{
                   --name FUNCTION_NAME
                   [--lang <ruby|python|node|csharp>]
                   [--gateway GATEWAY_URL]
+                  [--network NETWORK_NAME]
                   [--handler HANDLER_DIR]
                   [--fprocess PROCESS]
                   [--env ENVVAR=VALUE ...]
@@ -88,6 +90,11 @@ func runDeploy(cmd *cobra.Command, args []string) {
 			parsedServices.Provider.GatewayURL = gateway
 		}
 
+		// Override network if passed
+		if len(network) > 0 && network != defaultNetwork {
+			parsedServices.Provider.Network = network
+		}
+
 		if parsedServices != nil {
 			services = *parsedServices
 		}
@@ -123,7 +130,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		proxy.DeployFunction(fprocess, gateway, functionName, image, language, replace, envvars, defaultNetwork, constraints)
+		proxy.DeployFunction(fprocess, gateway, functionName, image, language, replace, envvars, network, constraints)
 	}
 }
 

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -22,6 +22,7 @@ var (
 var (
 	fprocess     string
 	functionName string
+	network      string
 	gateway      string
 	handler      string
 	image        string

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -41,7 +41,7 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	req := requests.CreateFunctionRequest{
 		EnvProcess:  fprocessTemplate,
 		Image:       image,
-		Network:     "func_functions", // todo: specify network as an override
+		Network:     network,
 		Service:     functionName,
 		EnvVars:     envVars,
 		Constraints: constraints,


### PR DESCRIPTION
## Description
Add ```--network``` flag to deploy command in order to override the network name

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] Issue to propose this change (#96)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
