### PR TITLE
Support ARM64 for Packet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ faas-cli
 faas-cli-darwin
 faas-cli-armhf
 faas-cli.exe
+faas-cli-arm64
 
 *.jpg
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ deploy:
   - faas-cli-darwin
   - faas-cli-armhf
   - faas-cli.exe
+  - faas-cli-amd64
   skip_cleanup: true
   on:
     tags: true

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -14,7 +14,8 @@ RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags 
  && GOARCH=arm GOARM=6 CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-armhf \
  && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-darwin \
  && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli \
- && CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli.exe
+ && CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli.exe \
+ && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-arm64
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
@@ -25,5 +26,6 @@ COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli                .
 COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli-darwin         .
 COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli-armhf          .
 COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli.exe            .
+COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli-arm64          .
 
 CMD ["./faas"]

--- a/build_redist.sh
+++ b/build_redist.sh
@@ -5,5 +5,6 @@ docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_p
  docker cp faas-cli:/root/faas-cli . && \
  docker cp faas-cli:/root/faas-cli-darwin . && \
  docker cp faas-cli:/root/faas-cli-armhf . && \
+ docker cp faas-cli:/root/faas-cli-arm64 . && \
  docker cp faas-cli:/root/faas-cli.exe . && \
  docker rm -f faas-cli


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Support ARM64 for Packet

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))

Packet have enterprise ARM64 servers available for testing and want to show OpenFaaS running at scale on ARM hardware. This provides a binary for the CLI and a template for Node.js.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Provision a Type2A at Packet.net - or use a SoC like a Pine64
Dockerfile for Node.js available in ./template/node-arm64

There is no official Node-Alpine image yet so this uses Debian instead as a base.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.